### PR TITLE
Adding option to be able to leave the file extension in the url

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -21,6 +21,7 @@ var path = require('path'),
  * @param {resolverOptions=} options Optional [options]{@link MarkdownServer~resolverOptions} to specify default page name and file extension
  * @param {string} [options.defaultPageName=index] Name of default document
  * @param {string} [options.fileExtension=md] File extension of Markdown files
+ * @param {boolean} [options.useExtensionInUrl=false] If true, the file extension will not be removed from the url when resolving it
  * @returns {string} Full path to Markdown file if it exists, otherwise null
  */
 exports = module.exports = function(urlPath, rootDir, options) {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -32,6 +32,9 @@ exports = module.exports = function(urlPath, rootDir, options) {
     if (ext.indexOf('.') !== 0)
         ext = '.' + ext;    // default is ".md"
 
+    if (options && options.useExtensionInUrl)
+        ext = '';
+
     var defPageName = (options && options.defaultPageName) ? options.defaultPageName : 'index';
 
     // root

--- a/lib/server.js
+++ b/lib/server.js
@@ -218,6 +218,7 @@ exports = module.exports = {
  * @alias resolverOptions
  * @property {string=} [defaultPagename=index] Name of default document
  * @property {string=} [fileExtension=md] File extension of Markdown files
+ * @property {boolean=} [useExtensionInUrl=false] If true, the file extension will not be removed from the url when resolving it
  */
 
 /**
@@ -246,7 +247,8 @@ function MarkdownServer(rootDirectory) {
     this.markedOptions = null;
     this.resolverOptions = {
         defaultPageName: 'index',   // name of default document in each sub folder
-        fileExtension: 'md'
+        fileExtension: 'md',
+        useExtensionInUrl: false
     };
 }
 

--- a/test/fixture/test-use-extension.md
+++ b/test/fixture/test-use-extension.md
@@ -1,0 +1,34 @@
+title: Hello World
+date: 2013-11-15 12:40:09
+tags:
+---
+
+Welcome to [Hexo](http://zespia.tw/hexo)! This is your very first post. Check [documentation](http://zespia.tw/hexo/docs) to learn how to use.
+
+---
+
+Some random points:
+
+- Innie
+- Minnie
+- Meinie
+- Moe
+
+![cat](http://random.com/cat.jpg)
+
+
+# This is the boss yo!
+
+Hello, how r u?
+
+Testing some html & characters **bam**
+
+
+``` javascript
+
+var obj = new Awesome('me');
+obj.emit();
+
+```
+
+

--- a/test/resolver.test.js
+++ b/test/resolver.test.js
@@ -96,4 +96,10 @@ describe('resolver', function() {
         should.exist(file);
         file.should.equal(path.resolve(rootDir, 'sub/custom.foo'));
     });
+
+    it('should resolve "/test-use-extension.md" with use extension in url option', function() {
+        var file = resolver('/test-use-extension.md', rootDir, { useExtensionInUrl: true });
+        should.exist(file);
+        file.should.equal(path.resolve(rootDir, 'test-use-extension.md'));
+    });
 });


### PR DESCRIPTION
Hi!

I love markdown-serve, but have the following issue: my .md files contain links to each other (e.g. `[link](otherFile.md)` ), which don't work with markdown-serve, because it adds the extension to the path during resolving, so ends up looking for `otherFile.md.md`. I added a new resolver option `useExtensionInUrl` which, when set to true, doesn't append the extension. Its default value is false, so if it is not set explicitly, everything works as before.

Usage: 

> app.use('/docs', mds.middleware({ 
    rootDirectory: './docs',
    view: 'markdown',
    preParse: true,
    resolverOptions: {
      defaultPageName: 'readme.md',
      useExtensionInUrl: true
    }
}));