### PR TITLE
When urlPath does not resolve - check for default.md using urlPath as a directory

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -58,7 +58,11 @@ exports = module.exports = function(urlPath, rootDir, options) {
     file = path.resolve(rootDir, urlPath.replace(/-/g, ' ') + ext);
     if (exists(file)) return file;
 
-    // check existence of each segment -- taking into account dashes -- and build up final path
+    // /name/defPageName (urlPath is a directory containing a default md file)
+    file = path.resolve(rootDir, urlPath + '/' + defPageName + ext);
+    if (exists(file)) return file;
+
+   // check existence of each segment -- taking into account dashes -- and build up final path
     var segs = urlPath.split('/');
     var u = rootDir;
     for (var i = 0; i < segs.length; i++) {


### PR DESCRIPTION
Hi @NagyBandi !

*markdown-serve* is awesome - thanks for making available to all!

I get questions (*and even ugly complaints*) from my site guests looking at site documentation which I deliver using *markdown-serve* middleware.

When they enter a URL like `https://mydomain.com/docs/ninja` ( **note** the missing `/` at the end of URL ). The markdown-serve middleware responds with *404 - Not found*.

In their thinking - they are asking for documentation on `ninja`. ( technically -  they are asking for the  'index.md' file from the  `/docs/ninja` **directory**. *Not* the `non-existing 'ninja.md' file ` from the `/docs` directory.  ( BTW - if 'ninja.md' *does* exist in `/docs` directory - markdown-server rightfully delivers it as we would expect! ).

 I tell them to put a `/` at the end of the URL and it will work. Which is silly for mere human mortals to remember - considering most can not remember what they had for breakfast.

>  Note:
Requiring a `/` at the end of a URL is similar to setting the `strict` option on `express.Router([options])`  - see [express API](https://expressjs.com/en/api.html). <br />
I find 'strict' mode is more important for REST API calls and such, where precision of URL requests is paramount.<br />
**IMHO - that level of URL strict-*ness* is kinda silly for documentation - as I generally **want** guests to find documentation easily - and what are .md files for *but* documentation?**

But anyway! - I transgress...

This pull request adds a few lines to `resolver.js` which ultimately will look for the `defPageName + ext` assuming that the URL is a path to that default  .md file.

Your comments are welcome and appreciated - what do you think?

@PotOfCoffee2Go
 


