### PR TITLE
Specify optional logger when setting up the middleware

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -19,7 +19,8 @@ var path = require('path'),
     parser = require('./parser'),
     _ = require('lodash'),
     mkdirp = require('mkdirp'),
-    fs = require('fs');
+    fs = require('fs'),
+    logger = null;
 
 exports = module.exports = {
     /**
@@ -100,7 +101,7 @@ exports = module.exports = {
      * If specified as a [preParseFn]{@link module:markdown-serve~preParseFn} function, will return the function result as the view model object to the view.
      * @param {handlerFn=} options.handler [handlerFn]{@link module:markdown-serve~handlerFn}. Provides full customization of middleware response. Make sure `view` is not
      * set when using this feature as that takes precedence.
-     *
+     * @param {Object=} options.logger Logger object - should respond to log function, optional replacement for console object
      * @example
      * // basic usage
      * // app.js
@@ -170,12 +171,19 @@ exports = module.exports = {
         if (options.resolverOptions)
             server.resolverOptions = options.resolverOptions;
 
+        if (options.logger)
+          logger = options.logger;
+
         return function(req, res, next) {
             if (req.method !== 'GET' && !options.handler) return next();
 
             server.get(req.path, function(err, result) {
                 if (err) {
-                    console.log(err);
+                    if (logger) {
+                        logger.log(err);
+                    } else {
+                      console.log(err);
+                    }
                     next();
                     return;   // need return here because next call (above) is inside a callback
                 }

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -300,9 +300,8 @@ describe('middleware()', function() {
     request(app)
       .get('/foo-bar')
       .expect(404)
-      .expect(function() {
-          return logger.called === true;
-      }).end(function() {
+      .expect(logger.called === true)
+      .end(function() {
           return done();
       });
   });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -281,6 +281,32 @@ describe('middleware()', function() {
             .expect(404, done);
     });
 
+  it('should call optional logger if path not found', function(done) {
+    var app = express();
+
+    // Simple logger mock
+    var logger = {
+      called: false,
+      log: function() {
+        this.called = true;
+      }
+    };
+
+    app.use(server.middleware({
+      rootDirectory: ROOT_DIR,
+      logger: logger
+    }));
+
+    request(app)
+      .get('/foo-bar')
+      .expect(404)
+      .expect(function() {
+          return logger.called === true;
+      }).end(function() {
+          return done();
+      });
+  });
+
     it('should next() if method is POST', function(done) {
         var app = express();
 


### PR DESCRIPTION
When encountering missing files the log message is called directly on console.log. For monitoring purposes I need to handle the message with the logging framework. Therefore I propose a new parameter logger which will  be called instead of the console. 

Tests are included. 